### PR TITLE
General improvements to Inventory Tasks

### DIFF
--- a/src/dte/amongus/corpses/basic/components/concretes/DeathSignComponent.java
+++ b/src/dte/amongus/corpses/basic/components/concretes/DeathSignComponent.java
@@ -7,15 +7,15 @@ import org.bukkit.block.Block;
 
 import dte.amongus.corpses.basic.BasicCorpse;
 import dte.amongus.corpses.basic.components.blocks.BlockChangeComponent;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 
 public class DeathSignComponent extends BlockChangeComponent
 {
-	public DeathSignComponent(BasicCorpse corpse, Block block, Material signMaterial, AUGamePlayer whoDied)
+	public DeathSignComponent(BasicCorpse corpse, Block block, Material signMaterial)
 	{
-		super(corpse, block, toSign(signMaterial, createLinesFor(whoDied)));
+		super(corpse, block, toSign(signMaterial, createLinesFor(corpse.whoDied())));
 	}
-	private static String[] createLinesFor(AUGamePlayer whoDied)
+	private static String[] createLinesFor(Crewmate whoDied)
 	{
 		String playerName = whoDied.getPlayer().getName();
 		

--- a/src/dte/amongus/corpses/reportablefinder/ReportableCorpseFinder.java
+++ b/src/dte/amongus/corpses/reportablefinder/ReportableCorpseFinder.java
@@ -1,9 +1,9 @@
 package dte.amongus.corpses.reportablefinder;
 
 import dte.amongus.corpses.AbstractCorpse;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 
 public interface ReportableCorpseFinder
 {
-	AbstractCorpse find(AUGamePlayer gamePlayer);
+	AbstractCorpse find(Crewmate crewmate);
 }

--- a/src/dte/amongus/corpses/reportablefinder/ReportableCorpsesWGFinder.java
+++ b/src/dte/amongus/corpses/reportablefinder/ReportableCorpsesWGFinder.java
@@ -7,7 +7,7 @@ import org.bukkit.Bukkit;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 import dte.amongus.corpses.AbstractCorpse;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.AUGame;
 import dte.amongus.games.players.Crewmate;
 import dte.amongus.hooks.WorldGuardHook;
 
@@ -24,24 +24,27 @@ public class ReportableCorpsesWGFinder implements ReportableCorpseFinder
 	}
 
 	@Override
-	public AbstractCorpse find(AUGamePlayer gamePlayer) 
+	public AbstractCorpse find(Crewmate crewmate) 
 	{
-		List<ProtectedRegion> playerRegions = this.wgHook.getPlayerRegions(gamePlayer.getPlayer());
+		List<ProtectedRegion> playerRegions = this.wgHook.getPlayerRegions(crewmate.getPlayer());
+		AUGame game = crewmate.getGame();
 		
 		return playerRegions.stream()
 				.filter(this::isCorpseRegion)
 				.findFirst() //the player might be inside multiple corpse regions, so choose an arbitrary one
-				.map(region -> Bukkit.getPlayer(getDeadCrewmateName(region)))
-				.map(deadCrewmate -> gamePlayer.getGame().getPlayer(deadCrewmate, Crewmate.class))
+				.map(region -> getDeadCrewmate(game, region))
 				.map(deadCrewmate -> deadCrewmate.getDeathContext().get().getCorpse())
 				.orElse(null);
 	}
+	
 	private boolean isCorpseRegion(ProtectedRegion region)
 	{
 		return region.getId().endsWith("-body");
 	}
-	private String getDeadCrewmateName(ProtectedRegion region) 
+	private Crewmate getDeadCrewmate(AUGame game, ProtectedRegion region) 
 	{
-		return region.getId().substring(0, region.getId().indexOf("-body"));
+		String crewmateName = region.getId().substring(0, region.getId().indexOf("-body"));
+		
+		return game.getPlayer(Bukkit.getPlayer(crewmateName), Crewmate.class);
 	}
 }

--- a/src/dte/amongus/events/games/AUDeathEvent.java
+++ b/src/dte/amongus/events/games/AUDeathEvent.java
@@ -4,23 +4,23 @@ import org.bukkit.event.HandlerList;
 
 import dte.amongus.deathcontext.DeathContext;
 import dte.amongus.games.AUGame;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 
 public class AUDeathEvent extends GameEvent
 {
-	private final AUGamePlayer whoDied;
+	private final Crewmate whoDied;
 	private final DeathContext context;
 	
 	private static final HandlerList HANDLERS = new HandlerList();
 	
-	public AUDeathEvent(AUGame game, AUGamePlayer whoDied, DeathContext context) 
+	public AUDeathEvent(AUGame game, Crewmate whoDied, DeathContext context) 
 	{
 		super(game);
 		
 		this.whoDied = whoDied;
 		this.context = context;
 	}
-	public AUGamePlayer whoDied() 
+	public Crewmate whoDied() 
 	{
 		return this.whoDied;
 	}

--- a/src/dte/amongus/listeners/games/BodyReportListener.java
+++ b/src/dte/amongus/listeners/games/BodyReportListener.java
@@ -7,7 +7,7 @@ import org.bukkit.event.Listener;
 
 import dte.amongus.corpses.AbstractCorpse;
 import dte.amongus.events.games.BodyReportEvent;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 import dte.amongus.internal.AUGameUtils;
 import dte.amongus.internal.GamePlayerUtils;
 
@@ -22,7 +22,7 @@ public class BodyReportListener implements Listener
 		notifyDeath(corpse.whoDied());
 	}
 	
-	private void notifyDeath(AUGamePlayer whoDied) 
+	private void notifyDeath(Crewmate whoDied) 
 	{
 		String coloredDeadName = GamePlayerUtils.getColoredName(whoDied);
 		

--- a/src/dte/amongus/listeners/games/ImpostorKillListener.java
+++ b/src/dte/amongus/listeners/games/ImpostorKillListener.java
@@ -56,7 +56,7 @@ public class ImpostorKillListener implements Listener
 			//TODO: add the sabotage map
 		}
 	}
-	private void sendKillMessages(AUGamePlayer impostor, AUGamePlayer crewmate, AUGame game) 
+	private void sendKillMessages(Impostor impostor, Crewmate crewmate, AUGame game) 
 	{
 		int crewmatesLeft = game.getAlivePlayers(Crewmate.class).size() - game.getAlivePlayers(Impostor.class).size();
 		impostor.getPlayer().sendMessage(IMPOSTOR_PREFIX + ChatColor.DARK_AQUA + crewmate.getPlayer().getName() + ChatColor.GRAY + " ate it! (" + ChatColor.AQUA + crewmatesLeft + ChatColor.GRAY + " Crewmates Left).");

--- a/src/dte/amongus/shiptasks/ProgressionTask.java
+++ b/src/dte/amongus/shiptasks/ProgressionTask.java
@@ -1,7 +1,6 @@
 package dte.amongus.shiptasks;
 
 import dte.amongus.games.AUGame;
-import dte.amongus.games.players.AUGamePlayer;
 import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.type.TaskType;
 
@@ -31,8 +30,8 @@ public abstract class ProgressionTask extends SimpleShipTask
 		}
 		return newProgression == 100;
 	}
-	public int getProgression(AUGamePlayer gamePlayer) 
+	public int getProgression(Crewmate crewmate) 
 	{
-		return (Integer) getOrPut(gamePlayer, "Progression", 0);
+		return (Integer) getOrPut(crewmate, "Progression", 0);
 	}
 }

--- a/src/dte/amongus/shiptasks/ShipTask.java
+++ b/src/dte/amongus/shiptasks/ShipTask.java
@@ -11,9 +11,6 @@ public interface ShipTask
 	TaskType getType();
 	AUGame getGame();
 	
-	void setFinished(Crewmate crewmate);
-	boolean hasFinished(Crewmate crewmate);
-	
 	default void onFinish(Crewmate crewmate){}
 	default void onStart(Crewmate crewmate){}
 }

--- a/src/dte/amongus/shiptasks/SimpleShipTask.java
+++ b/src/dte/amongus/shiptasks/SimpleShipTask.java
@@ -1,10 +1,8 @@
 package dte.amongus.shiptasks;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import dte.amongus.games.AUGame;
@@ -16,7 +14,6 @@ public abstract class SimpleShipTask implements ShipTask
 	private final String name, description;
 	private final TaskType type;
 	private final AUGame game;
-	private final Set<Crewmate> finishers = new HashSet<>();
 	private final Map<Crewmate, Map<String, Object>> playersData = new HashMap<>();
 	
 	protected SimpleShipTask(String name, String description, TaskType type, AUGame game) 
@@ -49,18 +46,6 @@ public abstract class SimpleShipTask implements ShipTask
 	public AUGame getGame() 
 	{
 		return this.game;
-	}
-	
-	@Override
-	public void setFinished(Crewmate crewmate) 
-	{
-		this.finishers.add(crewmate);
-	}
-	
-	@Override
-	public boolean hasFinished(Crewmate crewmate) 
-	{
-		return this.finishers.contains(crewmate);
 	}
 
 	protected void setData(Crewmate crewmate, String data, Object value)

--- a/src/dte/amongus/shiptasks/SimpleShipTask.java
+++ b/src/dte/amongus/shiptasks/SimpleShipTask.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import dte.amongus.games.AUGame;
-import dte.amongus.games.players.AUGamePlayer;
 import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.type.TaskType;
 
@@ -17,8 +16,8 @@ public abstract class SimpleShipTask implements ShipTask
 	private final String name, description;
 	private final TaskType type;
 	private final AUGame game;
-	private final Map<AUGamePlayer, Map<String, Object>> playersData = new HashMap<>();
 	private final Set<Crewmate> finishers = new HashSet<>();
+	private final Map<Crewmate, Map<String, Object>> playersData = new HashMap<>();
 	
 	protected SimpleShipTask(String name, String description, TaskType type, AUGame game) 
 	{
@@ -27,7 +26,7 @@ public abstract class SimpleShipTask implements ShipTask
 		this.type = type;
 		this.game = game;
 	}
-
+	
 	@Override
 	public String getName() 
 	{
@@ -51,49 +50,49 @@ public abstract class SimpleShipTask implements ShipTask
 	{
 		return this.game;
 	}
-
+	
 	@Override
 	public void setFinished(Crewmate crewmate) 
 	{
 		this.finishers.add(crewmate);
 	}
-
+	
 	@Override
 	public boolean hasFinished(Crewmate crewmate) 
 	{
 		return this.finishers.contains(crewmate);
 	}
 
-	protected void setData(AUGamePlayer gamePlayer, String data, Object value)
+	protected void setData(Crewmate crewmate, String data, Object value)
 	{
-		Map<String, Object> playerData = this.playersData.computeIfAbsent(gamePlayer, p -> new HashMap<>());
+		Map<String, Object> playerData = this.playersData.computeIfAbsent(crewmate, c -> new HashMap<>());
 		
 		playerData.put(data, value);
 	}
-	protected void removeData(AUGamePlayer gamePlayer, String data)
+	protected void removeData(Crewmate crewmate, String data)
 	{
-		Map<String, Object> playerData = this.playersData.get(gamePlayer);
+		Map<String, Object> playerData = this.playersData.get(crewmate);
 		
 		if(playerData != null)
 			playerData.remove(data);
 	}
-	protected <T> Optional<T> getData(AUGamePlayer gamePlayer, String data, Class<T> valueClass)
+	protected <T> Optional<T> getData(Crewmate crewmate, String data, Class<T> valueClass)
 	{
-		Map<String, Object> playerData = this.playersData.get(gamePlayer);
+		Map<String, Object> playerData = this.playersData.get(crewmate);
 
 		return Optional.ofNullable(playerData)
 				.map(playerDataArg -> playerDataArg.get(data))
 				.map(valueClass::cast);
 	}
-	protected <T> T getOrPut(AUGamePlayer gamePlayer, String data, T defaultIfAbsent) 
+	protected <T> T getOrPut(Crewmate crewmate, String data, T defaultIfAbsent) 
 	{
-		return getOrPut(gamePlayer, data, () -> defaultIfAbsent);
+		return getOrPut(crewmate, data, () -> defaultIfAbsent);
 	}
 	
 	@SuppressWarnings("unchecked")
-	protected <T> T getOrPut(AUGamePlayer gamePlayer, String data, Supplier<T> defaultSupplier)
+	protected <T> T getOrPut(Crewmate crewmate, String data, Supplier<T> defaultSupplier)
 	{
-		Map<String, Object> playerData = this.playersData.computeIfAbsent(gamePlayer, p -> new HashMap<>());
+		Map<String, Object> playerData = this.playersData.computeIfAbsent(crewmate, c -> new HashMap<>());
 
 		return (T) playerData.computeIfAbsent(data, v -> defaultSupplier.get());
 	}

--- a/src/dte/amongus/shiptasks/inventory/TaskInventoryManager.java
+++ b/src/dte/amongus/shiptasks/inventory/TaskInventoryManager.java
@@ -5,14 +5,14 @@ import java.util.regex.Pattern;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 
 public abstract class TaskInventoryManager
 {
 	private static final Pattern TITLE_PATTERN = Pattern.compile("Task > [a-zA-Z0-9 ]+");
 
-	public abstract Inventory createInventory(AUGamePlayer opener);
-	public abstract void onInventoryClick(InventoryClickEvent event); //TODO: change to return a boolean that indicates whether the player finished the task
+	public abstract Inventory createInventory(Crewmate opener);
+	public abstract void onInventoryClick(Crewmate crewmate, InventoryClickEvent event); //TODO: change to return a boolean that indicates whether the player finished the task
 	public abstract boolean wasInvolvedAt(InventoryClickEvent event);
 	
 	protected static String createTitle(String description)
@@ -23,7 +23,7 @@ public abstract class TaskInventoryManager
 	protected static boolean testInventory(InventoryClickEvent event, String description) 
 	{
 		String title = event.getView().getTitle();
-
+		
 		if(TITLE_PATTERN.matcher(description).matches())
 			return false;
 		

--- a/src/dte/amongus/shiptasks/list/cleano2filter/CleanO2FilterInventoryManager.java
+++ b/src/dte/amongus/shiptasks/list/cleano2filter/CleanO2FilterInventoryManager.java
@@ -22,7 +22,7 @@ import org.bukkit.inventory.ItemStack;
 import com.google.common.collect.Lists;
 
 import dte.amongus.AmongUs;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.inventory.TaskInventoryManager;
 import dte.amongus.utils.InventoryUtils;
 import dte.amongus.utils.blocks.BlockUtils;
@@ -44,7 +44,7 @@ public class CleanO2FilterInventoryManager extends TaskInventoryManager
 	}
 
 	@Override
-	public Inventory createInventory(AUGamePlayer opener) 
+	public Inventory createInventory(Crewmate opener) 
 	{
 		Inventory inventory = Bukkit.createInventory(null, 9 * 6, createTitle("Clean the Leaves"));
 		InventoryUtils.buildWalls(inventory, createDummyItem(Material.BLACK_STAINED_GLASS_PANE));
@@ -64,35 +64,34 @@ public class CleanO2FilterInventoryManager extends TaskInventoryManager
 	}
 
 	@Override
-	public void onInventoryClick(InventoryClickEvent event) 
+	public void onInventoryClick(Crewmate crewmate, InventoryClickEvent event) 
 	{
 		Inventory inventory = event.getInventory();
 		ItemStack item = event.getCurrentItem();
-		Player player = (Player) event.getWhoClicked();
-		AUGamePlayer gamePlayer = this.cleanO2FilterTask.getGame().getPlayer(player);
-		Optional<Integer> currentLeafIndex = this.cleanO2FilterTask.getCurrentLeafData(gamePlayer);
+		Player crewmatePlayer = (Player) event.getWhoClicked();
+		Optional<Integer> currentLeafIndex = this.cleanO2FilterTask.getCurrentLeafData(crewmate);
 
 		if(BlockUtils.isLeaf(item.getType()))
 		{
 			if(currentLeafIndex.isPresent())
 			{
-				player.sendMessage(RED + "One by One!");
+				crewmatePlayer.sendMessage(RED + "One by One!");
 				return;
 			}
 			GlowEffect.addGlow(item);
-			this.cleanO2FilterTask.setCurrentLeafData(gamePlayer, event.getRawSlot());
+			this.cleanO2FilterTask.setCurrentLeafData(crewmate, event.getRawSlot());
 			setLeavesTo(inventory, leaf -> CleanO2FilterInventoryManager.createInformativeLeaf(leaf.getType()));
 		}
 		else if(item.getType() == Material.CHAIN) 
 		{
 			if(!currentLeafIndex.isPresent()) 
 			{
-				player.sendMessage(RED + "You have to select a Leaf!");
+				crewmatePlayer.sendMessage(RED + "You have to select a Leaf!");
 				return;
 			}
 			List<Integer> exitPath = calculateExitPath(currentLeafIndex.get(), event.getRawSlot());
 
-			new LeafCleaningRunnable(this.cleanO2FilterTask, inventory, gamePlayer, exitPath, this.cleaningSound).runTaskTimer(AmongUs.getInstance(), 0, 5);
+			new LeafCleaningRunnable(this.cleanO2FilterTask, inventory, crewmate, exitPath, this.cleaningSound).runTaskTimer(AmongUs.getInstance(), 0, 5);
 		}
 	}
 

--- a/src/dte/amongus/shiptasks/list/cleano2filter/CleanO2FilterTask.java
+++ b/src/dte/amongus/shiptasks/list/cleano2filter/CleanO2FilterTask.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.bukkit.Sound;
 
 import dte.amongus.games.AUGame;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.SimpleShipTask;
 import dte.amongus.shiptasks.inventory.InventoryTask;
 import dte.amongus.shiptasks.inventory.TaskInventoryManager;
@@ -35,18 +35,18 @@ public class CleanO2FilterTask extends SimpleShipTask implements InventoryTask
 		return this.leavesAmount;
 	}
 	
-	public Optional<Integer> getCurrentLeafData(AUGamePlayer gamePlayer)
+	public Optional<Integer> getCurrentLeafData(Crewmate crewmate)
 	{
-		return getData(gamePlayer, "Current Leaf Index", Integer.class);
+		return getData(crewmate, "Current Leaf Index", Integer.class);
 	}
 	
-	public void setCurrentLeafData(AUGamePlayer gamePlayer, int leafIndex) 
+	public void setCurrentLeafData(Crewmate crewmate, int leafIndex) 
 	{
-		setData(gamePlayer, "Current Leaf Index", leafIndex);
+		setData(crewmate, "Current Leaf Index", leafIndex);
 	}
 	
-	public void removeCurrentLeafData(AUGamePlayer gamePlayer) 
+	public void removeCurrentLeafData(Crewmate crewmate) 
 	{
-		removeData(gamePlayer, "Current Leaf Index");
+		removeData(crewmate, "Current Leaf Index");
 	}
 }

--- a/src/dte/amongus/shiptasks/list/cleano2filter/LeafCleaningRunnable.java
+++ b/src/dte/amongus/shiptasks/list/cleano2filter/LeafCleaningRunnable.java
@@ -9,13 +9,13 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import dte.amongus.AmongUs;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 
 public class LeafCleaningRunnable extends BukkitRunnable
 {
 	private final CleanO2FilterTask cleanO2FilterTask;
 	private final Inventory taskInventory;
-	private final AUGamePlayer cleanerGamePlayer;
+	private final Crewmate cleaner;
 	private final List<Integer> exitPath;
 	private final Sound cleaningSound;
 	private final int chainIndex;
@@ -23,11 +23,11 @@ public class LeafCleaningRunnable extends BukkitRunnable
 	private ItemStack chainItem; //before the chain is opened(the chain is removed from the inventory), it's saved here
 	private int currentPathIndex = 1;
 
-	public LeafCleaningRunnable(CleanO2FilterTask cleanO2FilterTask, Inventory taskInventory, AUGamePlayer cleanerGamePlayer, List<Integer> exitPath, Sound cleaningSound) 
+	public LeafCleaningRunnable(CleanO2FilterTask cleanO2FilterTask, Inventory taskInventory, Crewmate cleaner, List<Integer> exitPath, Sound cleaningSound) 
 	{
 		this.cleanO2FilterTask = cleanO2FilterTask;
 		this.taskInventory = taskInventory;
-		this.cleanerGamePlayer = cleanerGamePlayer;
+		this.cleaner = cleaner;
 		this.exitPath = exitPath;
 		this.cleaningSound = cleaningSound;
 		this.chainIndex = exitPath.get(exitPath.size()-2);
@@ -37,14 +37,14 @@ public class LeafCleaningRunnable extends BukkitRunnable
 	public void run()
 	{
 		forwardLeaf();
-		this.cleanerGamePlayer.getPlayer().playSound(this.cleanerGamePlayer.getPlayer().getLocation(), this.cleaningSound, 1, 1);
+		this.cleaner.getPlayer().playSound(this.cleaner.getPlayer().getLocation(), this.cleaningSound, 1, 1);
 		this.currentPathIndex++;
 		
 		if(this.currentPathIndex == this.exitPath.size()) 
 		{
 			closeChain();
 			Bukkit.getScheduler().runTaskLater(AmongUs.getInstance(), this::removeLeaf, 10);
-			this.cleanO2FilterTask.removeCurrentLeafData(this.cleanerGamePlayer);
+			this.cleanO2FilterTask.removeCurrentLeafData(this.cleaner);
 			
 			//return the (Left Click) to the leaves' names
 			CleanO2FilterInventoryManager.setLeavesTo(this.taskInventory, leaf -> CleanO2FilterInventoryManager.createLeaf(leaf.getType()));

--- a/src/dte/amongus/shiptasks/list/enterid/EnterIDInventoryManager.java
+++ b/src/dte/amongus/shiptasks/list/enterid/EnterIDInventoryManager.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import dte.amongus.AmongUs;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.inventory.TaskInventoryManager;
 import dte.amongus.utils.InventoryUtils;
 import dte.amongus.utils.items.GlowEffect;
@@ -37,7 +37,7 @@ public class EnterIDInventoryManager extends TaskInventoryManager
 	}
 
 	@Override
-	public Inventory createInventory(AUGamePlayer opener)
+	public Inventory createInventory(Crewmate opener)
 	{
 		Inventory inventory = Bukkit.createInventory(null, 6 * 9, createTitle(String.format("Your ID is %d", this.enterIDTask.getPersonalID(opener).get())));
 		
@@ -61,10 +61,9 @@ public class EnterIDInventoryManager extends TaskInventoryManager
 
 	@SuppressWarnings("incomplete-switch")
 	@Override
-	public void onInventoryClick(InventoryClickEvent event) 
+	public void onInventoryClick(Crewmate crewmate, InventoryClickEvent event) 
 	{
-		Player player = (Player) event.getWhoClicked();
-		AUGamePlayer gamePlayer = this.enterIDTask.getGame().getPlayer(player);
+		Player crewmatePlayer = (Player) event.getWhoClicked();
 		ItemStack item = event.getCurrentItem();
 
 		switch(item.getType()) 
@@ -77,32 +76,32 @@ public class EnterIDInventoryManager extends TaskInventoryManager
 			
 			try 
 			{
-				this.enterIDTask.enterDigit(gamePlayer, getDigit(item));
+				this.enterIDTask.enterDigit(crewmate, getDigit(item));
 			}
 			catch(ArithmeticException exception) 
 			{
-				player.sendMessage(ChatColor.RED + "Too Many Digits!");
+				crewmatePlayer.sendMessage(ChatColor.RED + "Too Many Digits!");
 				return;
 			}
 			
 			//update the new digit
-			event.getInventory().setItem(PAPER_INDEX, createPaperItem(this.enterIDTask.getEnteredID(gamePlayer).get()));
-			player.playSound(player.getLocation(), this.digitEnterSound, 1, 1);
+			event.getInventory().setItem(PAPER_INDEX, createPaperItem(this.enterIDTask.getEnteredID(crewmate).get()));
+			crewmatePlayer.playSound(crewmatePlayer.getLocation(), this.digitEnterSound, 1, 1);
 			break;
 		case GREEN_TERRACOTTA:
-			Integer enteredID = this.enterIDTask.getEnteredID(gamePlayer).orElse(null);
+			Integer enteredID = this.enterIDTask.getEnteredID(crewmate).orElse(null);
 
 			if(enteredID == null)
 			{
-				player.sendMessage(ChatColor.RED + "What's your Personal ID?");
+				crewmatePlayer.sendMessage(ChatColor.RED + "What's your Personal ID?");
 				return;
 			}
-			if(!this.enterIDTask.getPersonalID(gamePlayer).get().equals(enteredID))
+			if(!this.enterIDTask.getPersonalID(crewmate).get().equals(enteredID))
 			{
-				player.sendMessage(ChatColor.RED + "Invalid Personal ID!");
+				crewmatePlayer.sendMessage(ChatColor.RED + "Invalid Personal ID!");
 				return;
 			}
-			player.sendMessage(ChatColor.GREEN + "Success - You were successfully identified.");
+			crewmatePlayer.sendMessage(ChatColor.GREEN + "Success - You were successfully identified.");
 			break;
 		}
 	}

--- a/src/dte/amongus/shiptasks/list/enterid/EnterIDTask.java
+++ b/src/dte/amongus/shiptasks/list/enterid/EnterIDTask.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.bukkit.Sound;
 
 import dte.amongus.games.AUGame;
-import dte.amongus.games.players.AUGamePlayer;
 import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.SimpleShipTask;
 import dte.amongus.shiptasks.inventory.InventoryTask;
@@ -31,21 +30,21 @@ public class EnterIDTask extends SimpleShipTask implements InventoryTask
 		return this.inventoryManager;
 	}
 	
-	public Optional<Integer> getPersonalID(AUGamePlayer gamePlayer) 
+	public Optional<Integer> getPersonalID(Crewmate crewmate) 
 	{
-		return getData(gamePlayer, "Personal ID", Integer.class);
+		return getData(crewmate, "Personal ID", Integer.class);
 	}
 	
-	public Optional<Integer> getEnteredID(AUGamePlayer gamePlayer)
+	public Optional<Integer> getEnteredID(Crewmate crewmate)
 	{
-		return getData(gamePlayer, "Entered ID", Integer.class);
+		return getData(crewmate, "Entered ID", Integer.class);
 	}
 	
-	public void enterDigit(AUGamePlayer gamePlayer, int digit) throws ArithmeticException
+	public void enterDigit(Crewmate crewmate, int digit) throws ArithmeticException
 	{
-		int currentEnteredID = getOrPut(gamePlayer, "Entered ID", 0);
+		int currentEnteredID = getOrPut(crewmate, "Entered ID", 0);
 
-		setData(gamePlayer, "Entered ID", NumberUtils.add(currentEnteredID, digit));
+		setData(crewmate, "Entered ID", NumberUtils.add(currentEnteredID, digit));
 	}
 	
 	@Override

--- a/src/dte/amongus/shiptasks/list/stabilizesteering/StabilizeSteeringInventoryManager.java
+++ b/src/dte/amongus/shiptasks/list/stabilizesteering/StabilizeSteeringInventoryManager.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.inventory.TaskInventoryManager;
 import dte.amongus.utils.InventoryUtils;
 import dte.amongus.utils.items.ItemBuilder;
@@ -29,7 +29,7 @@ public class StabilizeSteeringInventoryManager extends TaskInventoryManager
 	}
 
 	@Override
-	public Inventory createInventory(AUGamePlayer opener) 
+	public Inventory createInventory(Crewmate opener) 
 	{
 		Inventory inventory = Bukkit.createInventory(null, 9 * 6, createTitle("Stabilize The Steering"));
 		InventoryUtils.fillEmptySlots(inventory, createDummyItem(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
@@ -49,11 +49,9 @@ public class StabilizeSteeringInventoryManager extends TaskInventoryManager
 		
 		return inventory;
 	}
-
-	
 	
 	@Override
-	public void onInventoryClick(InventoryClickEvent event) 
+	public void onInventoryClick(Crewmate crewmate, InventoryClickEvent event) 
 	{
 		if(event.getRawSlot() != NEW_TARGET_INDEX)
 			return;
@@ -65,8 +63,8 @@ public class StabilizeSteeringInventoryManager extends TaskInventoryManager
 		inventory.setItem(NEW_TARGET_INDEX, new ItemBuilder(Material.WHITE_WOOL, GREEN + "Success!").createCopy());
 		inventory.setItem(PREVIOUS_TARGET_INDEX, createDummyItem(Material.LIGHT_BLUE_STAINED_GLASS_PANE));
 		
-		Player player = (Player) event.getWhoClicked();
-		player.playSound(player.getLocation(), this.steeringSound, 1, 1);
+		Player crewmatePlayer = (Player) event.getWhoClicked();
+		crewmatePlayer.playSound(crewmatePlayer.getLocation(), this.steeringSound, 1, 1);
 	}
 
 	@Override

--- a/src/dte/amongus/shiptasks/list/wires/WiresInventoryManager.java
+++ b/src/dte/amongus/shiptasks/list/wires/WiresInventoryManager.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Sets;
 
 import dte.amongus.AmongUs;
 import dte.amongus.cooldown.Cooldown;
-import dte.amongus.games.players.AUGamePlayer;
 import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.inventory.TaskInventoryManager;
 import dte.amongus.utils.InventoryUtils;
@@ -55,7 +54,7 @@ public class WiresInventoryManager extends TaskInventoryManager
 	}
 	
 	@Override
-	public Inventory createInventory(AUGamePlayer opener) 
+	public Inventory createInventory(Crewmate crewmate) 
 	{
 		Inventory inventory = Bukkit.createInventory(null, 6 * 9, createTitle("Fix The Wires"));
 		InventoryUtils.buildWalls(inventory, createDummyItem(Material.BLACK_STAINED_GLASS_PANE));
@@ -85,41 +84,41 @@ public class WiresInventoryManager extends TaskInventoryManager
 	}
 
 	@Override
-	public void onInventoryClick(InventoryClickEvent event) 
+	public void onInventoryClick(Crewmate crewmate, InventoryClickEvent event) 
 	{
 		ItemStack wire = event.getCurrentItem();
 		
 		if(!WIRES_MATERIALS.contains(wire.getType()))
 			return;
 		
-		Player player = (Player) event.getWhoClicked();
+		Player crewmatePlayer = (Player) event.getWhoClicked();
 		
-		if(WORK_COOLDOWN.wasRejected(player)) 
+		if(WORK_COOLDOWN.wasRejected(crewmatePlayer)) 
 			return;
 		
-		Crewmate crewmate = this.wiresTask.getGame().getPlayer(player, Crewmate.class);
 		Pair<Integer, ItemStack> currentWireData = this.wiresTask.getCurrentWire(crewmate).orElse(null);
 
 		if(currentWireData == null)
 		{
 			if(!isLeftSlot(event.getRawSlot())) 
 			{
-				player.sendMessage(ChatColor.RED + "You have to click a Left Wire first!");
+				crewmatePlayer.sendMessage(ChatColor.RED + "You have to click a Left Wire first!");
 				return;
 			}
 			if(event.getInventory().getItem(event.getRawSlot()+1) != null) 
 			{
-				player.sendMessage(ChatColor.RED + "Wire already connected!");
+				crewmatePlayer.sendMessage(ChatColor.RED + "Wire already connected!");
 				return;
 			}
 			GlowEffect.addGlow(wire);
 			this.wiresTask.setCurrentWire(crewmate, event.getRawSlot(), wire);
+			return;
 		}
 		int rightSlot = getRightSlot(currentWireData.getFirst());
 		
 		if(event.getRawSlot() == rightSlot)
 		{
-			WORK_COOLDOWN.put(player, TimeUnit.SECONDS, 3);
+			WORK_COOLDOWN.put(crewmatePlayer, TimeUnit.SECONDS, 3);
 			
 			ItemStack rightWire = event.getInventory().getItem(rightSlot);
 			GlowEffect.addGlow(rightWire);

--- a/src/dte/amongus/shiptasks/list/wires/WiresTask.java
+++ b/src/dte/amongus/shiptasks/list/wires/WiresTask.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.bukkit.inventory.ItemStack;
 
 import dte.amongus.games.AUGame;
-import dte.amongus.games.players.AUGamePlayer;
+import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.ProgressionTask;
 import dte.amongus.shiptasks.inventory.InventoryTask;
 import dte.amongus.shiptasks.inventory.TaskInventoryManager;
@@ -29,19 +29,19 @@ public class WiresTask extends ProgressionTask implements InventoryTask
 		return this.inventoryManager;
 	}
 	
-	public void setCurrentWire(AUGamePlayer gamePlayer, int inventorySlot, ItemStack wire) 
+	public void setCurrentWire(Crewmate crewmate, int inventorySlot, ItemStack wire) 
 	{
-		setData(gamePlayer, "Current Wire", Pair.of(inventorySlot, wire));
+		setData(crewmate, "Current Wire", Pair.of(inventorySlot, wire));
 	}
 	
-	public void removeCurrentWire(AUGamePlayer gamePlayer) 
+	public void removeCurrentWire(Crewmate crewmate) 
 	{
-		removeData(gamePlayer, "Current Wire");
+		removeData(crewmate, "Current Wire");
 	}
 	
 	@SuppressWarnings("unchecked") //safe cast if the API is used correctly
-	public Optional<Pair<Integer, ItemStack>> getCurrentWire(AUGamePlayer gamePlayer)
+	public Optional<Pair<Integer, ItemStack>> getCurrentWire(Crewmate crewmate)
 	{
-		return getData(gamePlayer, "Current Wire", Pair.class).map(pair -> (Pair<Integer, ItemStack>) pair);
+		return getData(crewmate, "Current Wire", Pair.class).map(pair -> (Pair<Integer, ItemStack>) pair);
 	}
 }

--- a/src/dte/amongus/shiptasks/service/ShipTaskService.java
+++ b/src/dte/amongus/shiptasks/service/ShipTaskService.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import dte.amongus.games.players.AUGamePlayer;
 import dte.amongus.games.players.Crewmate;
 import dte.amongus.shiptasks.ShipTask;
 
@@ -12,9 +11,9 @@ public class ShipTaskService
 {
 	private final Map<Crewmate, ShipTask> currentlyDoing = new HashMap<>();
 	
-	public Optional<ShipTask> getPlayerTask(AUGamePlayer gamePlayer)
+	public Optional<ShipTask> getPlayerTask(Crewmate crewmate)
 	{
-		return Optional.ofNullable(this.currentlyDoing.get(gamePlayer));
+		return Optional.ofNullable(this.currentlyDoing.get(crewmate));
 	}
 	public void setDoing(Crewmate crewmate, ShipTask task) 
 	{


### PR DESCRIPTION
1. They don't save a list of finishers, Crewmate does that instead.

2.1) Their managers get the Crewmate object when interacted, so there's no need to access the task's game object in order to get it from there.
2.2) Replaced a lot of AUGamePlayer instances with the contextual-correct subtypes (Should have been done in a different branch)